### PR TITLE
Added Location Validation to forms

### DIFF
--- a/assets/src/js/main.js
+++ b/assets/src/js/main.js
@@ -69,6 +69,24 @@
 		}
 	});
 
+	//Location Select Validation
+	$(document).on('blur', 'input#longitude', function() {
+		var longitudeInput = $(this);
+		var latitudeInput = longitudeInput.closest('form').find('input#latitude');
+	
+		var longitudeValue = parseFloat(longitudeInput.val());
+		var latitudeValue = parseFloat(latitudeInput.val());
+	
+		if (!isNaN(longitudeValue) && !isNaN(latitudeValue)) {
+			if (longitudeValue < -124.785543 || longitudeValue > -66.945554 
+				|| latitudeValue < 24.446667 || latitudeValue > 49.382812) {
+				alert('Coordinates must fall within continental USA');
+				longitudeInput.val('');
+				latitudeInput.val('');
+			}
+		}
+	});	
+
 	// toggle match details display
 	$(document).on('click', '.toggle-row', function() {
 		if( $(this).closest("tr").next("tr").hasClass('show') ) {


### PR DESCRIPTION
Formerly, adding coordinates in unreachable locations(the ocean, places outside the continental US) to one of the forms would crash the python code. I've added some validation code meant to stop users from entering invalid coordinates.